### PR TITLE
replace wrongly used lstrip rstrip with removeprefix and removesuffix

### DIFF
--- a/ws.py
+++ b/ws.py
@@ -281,7 +281,7 @@ def historicalCarbon(region="EARTH"):
     if region == "EARTH":
         df /= 1000  # global GHG in Gt CO2e
 
-    df.index.rename("time", True)
+    df.index.rename("time", inplace=True)
     df = df.reset_index()
     df["value"] = df.pop(0)
     return df.to_dict(orient="records")
@@ -295,7 +295,7 @@ def populationOverTime(region):
     df = dsGlobal.Population.sel(
         Scenario=scenario, Region=region, Time=slice(start, end)
     ).to_pandas()
-    df.index.rename("time", True)
+    df.index.rename("time", inplace=True)
     df = df.dropna().reset_index()  # Note the missing data!
     df["value"] = df.pop(0)
     return df.to_dict(orient="records")
@@ -309,7 +309,7 @@ def gdpOverTime(region):
     df = dsGlobal.Population.sel(
         Scenario=scenario, Region=region, Time=slice(start, end)
     ).to_pandas()
-    df.index.rename("time", True)
+    df.index.rename("time", inplace=True)
     df = df.dropna().reset_index()  # Note the missing data!
     df["value"] = df.pop(0)
     return df.to_dict(orient="records")
@@ -410,7 +410,7 @@ def policyPathway(policy, region):
     if region == "EARTH":
         df /= 1000  # global GHG in Gt CO2e
 
-    df.index.rename("time", True)
+    df.index.rename("time", inplace=True)
     return df.reset_index().to_dict(orient="records")
 
 

--- a/ws.py
+++ b/ws.py
@@ -11,6 +11,7 @@ Run with
 """
 from glob import glob
 from json import loads
+import os
 from pathlib import Path
 
 from flask import Flask, jsonify, request
@@ -108,8 +109,8 @@ def pathwaySelection():
 
 available_region_files = set(
     [
-        r.lstrip("/data/DataUpdate_02_2024/xr_alloc_").rstrip(".nc").lstrip("\\xr_alloc")
-        for r in glob("/data/DataUpdate_02_2024/xr_alloc_*.nc")
+        str(os.path.basename(p)).removeprefix("xr_alloc_").removesuffix(".nc") 
+        for p in glob("/data/DataUpdate_02_2024/xr_alloc_*.nc")
     ]
 )
 


### PR DESCRIPTION
This most likely fixes the bug where any country with a D or U in its ISO3 code gives an internal error.

The reason was that the `lstrip` and `rstrip` methods in python do not do what the original developer had in mind. `removeprefix` and `removesuffix` do. It does require python 3.9 or higher, so I hope that is the case on the production and acceptation server.