### PR TITLE
Current updates to country pages 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:  # Runs on all push events
+  push: # Runs on all push events
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
           - 'acceptance'
 
 env:
-  SITE_NAME: acc.carbonbudgetexplorer
+  SITE_NAME: carbonbudgetexplorer
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_SP }}
       - name: download build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SITE_NAME }}
           path: ${{ github.workspace }}/zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
           - 'acceptance'
 
 env:
-  SITE_NAME: carbonbudgetexplorer
+  SITE_NAME: acc.carbonbudgetexplorer
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: zip build
         run: zip -r ${{ env.SITE_NAME }}.zip .
       - name: publish build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.SITE_NAME }}.zip
           name: ${{ env.SITE_NAME }}

--- a/src/lib/CategoryPicker.svelte
+++ b/src/lib/CategoryPicker.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	export let value: string;
+	// TODO allow options to have a value or a label and value
+	export let options: string[];
+	export let name: string;
+
+	type ChangeEvent = Event & {
+		currentTarget: EventTarget & HTMLInputElement;
+	};
+
+	function updateValue(event: ChangeEvent) {
+		value = options[event.currentTarget.valueAsNumber].toString();
+	}
+
+	$: len = options.length;
+	$: valIndex = options.indexOf(value);
+	// when sliding all intermediate values are also fetched
+	// TODO could only fetch the value when the slider is released
+</script>
+
+<label>
+	<div class="flex flex-row gap-2">
+		<input
+			type="range"
+			class="range range-accent range-xs"
+			{name}
+			min="0"
+			max={len - 1}
+			step="1"
+			value={valIndex}
+			on:change={updateValue}
+		/>
+	</div>
+	<div class="flex w-full justify-between px-2 text-xs">
+		<!-- TODO make low/high settable to numbers/strings -->
+		{#each options as option, index}
+			<span class={index === valIndex ? 'font-extrabold' : ''}>{option}</span>
+		{/each}
+	</div>
+</label>

--- a/src/lib/GlobalQueryCard.svelte
+++ b/src/lib/GlobalQueryCard.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
 	import CustomRange from '$lib/CustomRange.svelte';
 	import type { PathWayQuery } from '$lib/api';
+	import CategoryPicker from './CategoryPicker.svelte';
 
 	export let query: PathWayQuery;
 	export let choices: Record<keyof PathWayQuery, string[]>;
 	export let onChange: (name: string, value: string) => void;
 
 	let defaults = {
-		temperature: 2.0,
-		exceedanceRisk: 0.5,
-		negativeEmissions: 0.5,
+		temperature: '2.0',
+		exceedanceRisk: '0.5',
+		negativeEmissions: '0.5',
 		timing: 'Immediate',
-		nonCO2red: 0.5
+		nonCO2red: '0.5'
 	};
 
 	let temperature: string = query.temperature || defaults.temperature;
@@ -98,11 +99,7 @@
 					data-tip="Analogous to IPCC WGIII scenarios, we distinguish global emission pathways with delayed (i.e., near-similar emissions up to 2030) and immediate action. Delayed action is infeasible with a temperature target of 1.5, so identical data will be shown in that case."
 					>ⓘ</span
 				>
-				<CustomRange
-					bind:value={timing}
-					options={choices.timing.map((d) => String(d))}
-					name="timing"
-				/>
+				<CategoryPicker bind:value={timing} options={choices.timing} name="timing" />
 			</p>
 		</div>
 	</div>

--- a/src/lib/PrincipleStatsTable.svelte
+++ b/src/lib/PrincipleStatsTable.svelte
@@ -25,13 +25,13 @@
 		</thead>
 		<tbody>
 			<tr>
-				<th>2030 reductions<br>relative to 2015</th>
+				<th>2030 reductions<br />relative to 2015</th>
 				{#each Object.entries(principles) as [id, { label, color }]}
 					<th>{reductions[id][2030] === null ? '-' : $tweenedReductions[id][2030].toFixed(0)}%</th>
 				{/each}
 			</tr>
 			<tr>
-				<th>2040 reductions<br>relative to 2015</th>
+				<th>2040 reductions<br />relative to 2015</th>
 				{#each Object.entries(principles) as [id, { label, color }]}
 					<th>{reductions[id][2040] === null ? '-' : $tweenedReductions[id][2040].toFixed(0)}%</th>
 				{/each}

--- a/src/lib/PrincipleStatsTable.svelte
+++ b/src/lib/PrincipleStatsTable.svelte
@@ -25,13 +25,13 @@
 		</thead>
 		<tbody>
 			<tr>
-				<th>2030 reductions</th>
+				<th>2030 reductions<br>relative to 2015</th>
 				{#each Object.entries(principles) as [id, { label, color }]}
 					<th>{reductions[id][2030] === null ? '-' : $tweenedReductions[id][2030].toFixed(0)}%</th>
 				{/each}
 			</tr>
 			<tr>
-				<th>2040 reductions</th>
+				<th>2040 reductions<br>relative to 2015</th>
 				{#each Object.entries(principles) as [id, { label, color }]}
 					<th>{reductions[id][2040] === null ? '-' : $tweenedReductions[id][2040].toFixed(0)}%</th>
 				{/each}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,8 +82,8 @@ export function pathwayQueryFromSearchParams(
 	};
 }
 
-export const API_URL = process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for production
-// export const API_URL = import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for development
+// export const API_URL = process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for production
+export const API_URL = import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for development
 
 async function getJSON(path: string, myfetch = fetch) {
 	let url = `${API_URL}${path}`;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -67,20 +67,12 @@ export function pathwayQueryFromSearchParams(
 	choices: Record<keyof PathWayQuery, string[]>
 ): PathWayQuery {
 	// TODO check each searchParam is in respective choices array
-	const temperature =
-		searchParams.get('temperature') ??
-		choices.temperature[5];//Math.floor(choices.temperature.length / 2)];
-	const exceedanceRisk =
-		searchParams.get('exceedanceRisk') ??
-		choices.exceedanceRisk[2];//[Math.floor(choices.exceedanceRisk.length / 2)];
+	const temperature = searchParams.get('temperature') ?? choices.temperature[5]; //Math.floor(choices.temperature.length / 2)];
+	const exceedanceRisk = searchParams.get('exceedanceRisk') ?? choices.exceedanceRisk[2]; //[Math.floor(choices.exceedanceRisk.length / 2)];
 	// TODO when more choices are available use Medium==1 as default
-	const negativeEmissions =
-		searchParams.get('negativeEmissions') ??
-		choices.negativeEmissions[3];//[Math.floor(choices.negativeEmissions.length / 2)];
-	const timing =
-		searchParams.get('timing') ?? choices.timing[1];//[Math.floor(choices.timing.length / 2)];
-	const nonCO2red =
-		searchParams.get('nonCO2red') ?? choices.nonCO2red[2];//[Math.floor(choices.nonCO2red.length / 2)];
+	const negativeEmissions = searchParams.get('negativeEmissions') ?? choices.negativeEmissions[3]; //[Math.floor(choices.negativeEmissions.length / 2)];
+	const timing = searchParams.get('timing') ?? choices.timing[1]; //[Math.floor(choices.timing.length / 2)];
+	const nonCO2red = searchParams.get('nonCO2red') ?? choices.nonCO2red[2]; //[Math.floor(choices.nonCO2red.length / 2)];
 	return {
 		temperature,
 		exceedanceRisk,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,8 +82,8 @@ export function pathwayQueryFromSearchParams(
 	};
 }
 
-// export const API_URL = process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for production
-export const API_URL = import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for development
+export const API_URL = process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for production
+// export const API_URL = import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'; // for development
 
 async function getJSON(path: string, myfetch = fetch) {
 	let url = `${API_URL}${path}`;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -189,9 +189,10 @@ export async function netzero(Region = 'EARTH'): Promise<UncertainTime[]> {
 }
 
 export async function indicators(ISO: string): Promise<{
-	ndcAmbition: number | null;
+	ndcAmbition: { min: number; max: number } | null;
 	historicalCarbon: number;
-	ndc: Record<number, [number, number]>;
+	ndc_inventory: Record<number, [number, number]>;
+	ndc_jones: Record<number, [number, number]>;
 }> {
 	return getJSON(`/indicators/${ISO}`);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -83,8 +83,8 @@ export function pathwayQueryFromSearchParams(
 }
 
 export const API_URL = dev
-       ? import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'
-       : process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'
+	? import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'
+	: process.env.CABE_API_URL ?? 'http://127.0.0.1:5000';
 
 async function getJSON(path: string, myfetch = fetch) {
 	let url = `${API_URL}${path}`;

--- a/src/lib/charts/components/NdcRange.svelte
+++ b/src/lib/charts/components/NdcRange.svelte
@@ -16,6 +16,7 @@
 	export let y0: number;
 	export let y1: number;
 	export let width = 2;
+	export let text0: string;
 
 	// TODO use color of ndc series on global page?
 	export let color = 'black';
@@ -42,7 +43,7 @@
 	/>
 	<circle
 		cx={$xScale(x)}
-		r={width}
+		r={width*2}
 		cy={$yScale(y0)}
 		stroke={color}
 		fill={color}
@@ -53,9 +54,18 @@
 		on:mouseout={() => dispatch('mouseout')}
 		role="tooltip"
 	/>
+	<text
+		x={$xScale(x)}
+		y={$yScale(y0) - 10}
+		fill={color}
+		text-anchor="middle"
+		font-size="12px"
+	> 
+		{text0}
+	</text>
 	<circle
 		cx={$xScale(x)}
-		r={width}
+		r={width*2}
 		cy={$yScale(y1)}
 		stroke={color}
 		fill={color}

--- a/src/lib/charts/components/NdcRange.svelte
+++ b/src/lib/charts/components/NdcRange.svelte
@@ -56,32 +56,32 @@
 		on:mouseout={() => dispatch('mouseout')}
 		role="tooltip"
 	/>
-	<text 
-		x={$xScale(x)} 
-		y={$yScale(y0) + 25}
-		fill={color} 
-		text-anchor="middle" 
-		font-size="13px"
+	<text
+		x={$xScale(x)}
+		y={$yScale(y0) + 30}
+		fill={color}
+		text-anchor="middle"
+		font-size="15px"
 		class="text-container"
 	>
 		{textNdcMin}
 	</text>
-	<text 
-		x={$xScale(x)} 
-		y={$yScale(y1) - 15} 
-		fill={color} 
-		text-anchor="middle" 
-		font-size="13px"
+	<text
+		x={$xScale(x)}
+		y={$yScale(y1) - 18}
+		fill={color}
+		text-anchor="middle"
+		font-size="15px"
 		class="text-container"
 	>
 		{textNdcMax}
 	</text>
-	<text 
-		x={$xScale(x) - 60} 
-		y={$yScale(y1) + 8} 
-		fill={color} 
-		text-anchor="middle" 
-		font-size="16px"
+	<text
+		x={$xScale(x) - 60}
+		y={$yScale(y1) + 8}
+		fill={color}
+		text-anchor="middle"
+		font-size="18px"
 		font-weight="bold"
 		class="text-container"
 	>

--- a/src/lib/charts/components/NdcRange.svelte
+++ b/src/lib/charts/components/NdcRange.svelte
@@ -110,7 +110,7 @@
 
 	.text-container {
 		position: relative; /* or absolute/fixed if needed */
-    	z-index: 9999; /* High value to ensure it is on top */
-    	background: white; /* Optional: to ensure text is readable */
+		z-index: 9999; /* High value to ensure it is on top */
+		background: white; /* Optional: to ensure text is readable */
 	}
 </style>

--- a/src/lib/charts/components/NdcRange.svelte
+++ b/src/lib/charts/components/NdcRange.svelte
@@ -16,7 +16,9 @@
 	export let y0: number;
 	export let y1: number;
 	export let width = 2;
-	export let text0: string;
+	export let textNdcMin: string;
+	export let textNdcMax: string;
+	export let textNdc: string;
 
 	// TODO use color of ndc series on global page?
 	export let color = 'black';
@@ -54,8 +56,36 @@
 		on:mouseout={() => dispatch('mouseout')}
 		role="tooltip"
 	/>
-	<text x={$xScale(x)} y={$yScale(y0) - 10} fill={color} text-anchor="middle" font-size="12px">
-		{text0}
+	<text 
+		x={$xScale(x)} 
+		y={$yScale(y0) + 25}
+		fill={color} 
+		text-anchor="middle" 
+		font-size="13px"
+		class="text-container"
+	>
+		{textNdcMin}
+	</text>
+	<text 
+		x={$xScale(x)} 
+		y={$yScale(y1) - 15} 
+		fill={color} 
+		text-anchor="middle" 
+		font-size="13px"
+		class="text-container"
+	>
+		{textNdcMax}
+	</text>
+	<text 
+		x={$xScale(x) - 60} 
+		y={$yScale(y1) + 8} 
+		fill={color} 
+		text-anchor="middle" 
+		font-size="16px"
+		font-weight="bold"
+		class="text-container"
+	>
+		{textNdc}
 	</text>
 	<circle
 		cx={$xScale(x)}
@@ -76,5 +106,11 @@
 	line {
 		fill: none;
 		stroke-width: 2;
+	}
+
+	.text-container {
+		position: relative; /* or absolute/fixed if needed */
+    	z-index: 9999; /* High value to ensure it is on top */
+    	background: white; /* Optional: to ensure text is readable */
 	}
 </style>

--- a/src/lib/charts/components/NdcRange.svelte
+++ b/src/lib/charts/components/NdcRange.svelte
@@ -43,7 +43,7 @@
 	/>
 	<circle
 		cx={$xScale(x)}
-		r={width*2}
+		r={width * 2}
 		cy={$yScale(y0)}
 		stroke={color}
 		fill={color}
@@ -54,18 +54,12 @@
 		on:mouseout={() => dispatch('mouseout')}
 		role="tooltip"
 	/>
-	<text
-		x={$xScale(x)}
-		y={$yScale(y0) - 10}
-		fill={color}
-		text-anchor="middle"
-		font-size="12px"
-	> 
+	<text x={$xScale(x)} y={$yScale(y0) - 10} fill={color} text-anchor="middle" font-size="12px">
 		{text0}
 	</text>
 	<circle
 		cx={$xScale(x)}
-		r={width*2}
+		r={width * 2}
 		cy={$yScale(y1)}
 		stroke={color}
 		fill={color}

--- a/src/lib/server/db/data.ts
+++ b/src/lib/server/db/data.ts
@@ -1,6 +1,6 @@
 import { open_borders } from './borders';
 
-export const dataDir = 'data'
+export const dataDir = 'data';
 
 const bordersPath = dataDir + '/ne_110m_admin_0_countries.geojson';
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -86,8 +86,8 @@
 				/></svg
 			>
 			<span
-				>This website has been updated with new data in September 2024. Please see the About page for more
-				information</span
+				>This website has been updated with new data in September 2024. Please see the About page
+				for more information</span
 			>
 		</div>
 		<div class="flex-none">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -86,7 +86,7 @@
 				/></svg
 			>
 			<span
-				>This website has been updated with new data in Feb 2024. Please see the About page for more
+				>This website has been updated with new NDC data in September 2024. Please see the About page for more
 				information</span
 			>
 		</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -86,7 +86,7 @@
 				/></svg
 			>
 			<span
-				>This website has been updated with new NDC data in September 2024. Please see the About page for more
+				>This website has been updated with new data in September 2024. Please see the About page for more
 				information</span
 			>
 		</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -86,8 +86,8 @@
 				/></svg
 			>
 			<span
-				>This website has been updated with new data in Feb 2024. Please see the About
-				page for more information</span
+				>This website has been updated with new data in Feb 2024. Please see the About page for more
+				information</span
 			>
 		</div>
 		<div class="flex-none">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -221,17 +221,21 @@
 					>, and in the long run based on GDP per capita (similar to Ability to Pay).
 				</QA>
 				<QA question="Why are there different absolute NDC values shown in the country graph?">
-					When NDCs area published by countries, they are expressed in relative terms (e.g. 30 % reduction in 2030 compared to 1990).
-					The absolute values are calculations that depend on the historical and baseline emission data used. We show two versions:
-					one based on the data we use for the Carbon Budget Explorer (Jones et al., 2021), and one based on the data used in the
+					When NDCs area published by countries, they are expressed in relative terms (e.g. 30 %
+					reduction in 2030 compared to 1990). The absolute values are calculations that depend on
+					the historical and baseline emission data used. We show two versions: one based on the
+					data we use for the Carbon Budget Explorer (Jones et al., 2021), and one based on the data
+					used in the
 					<a
 						href="https://themasites.pbl.nl/o/climate-ndc-policies-tool/"
 						target="_blank"
-						rel="noopener noreferrer">PBL NDC tool</a> (PRIMAP historical data).
+						rel="noopener noreferrer">PBL NDC tool</a
+					>
+					(PRIMAP historical data).
 					<br />
 					<br />
-					These values are only an indication. When precise NDC data is needed, it is better to refer to the official NDC documents.
-
+					These values are only an indication. When precise NDC data is needed, it is better to refer
+					to the official NDC documents.
 				</QA>
 				<QA question="Why are there no NDCs for European Member States?">
 					European Member States have a joint NDC, which is to reduce GHG emissions by at least 55 %
@@ -239,14 +243,14 @@
 					individual NDCs are available for European Member States.
 					<br />
 					<br />
-					The allocation of emission reductions to each Member State is determined via several Directives (ETS, ESR and others).
-					You can find
+					The allocation of emission reductions to each Member State is determined via several Directives
+					(ETS, ESR and others). You can find
 					<a
 						href="https://data.consilium.europa.eu/doc/document/ST-14286-2023-INIT/en/pdf"
 						target="_blank"
-						rel="noopener noreferrer">more information here.</a>
+						rel="noopener noreferrer">more information here.</a
+					>
 				</QA>
-
 			</section>
 			<section>
 				<h2 id="other">Other</h2>
@@ -261,15 +265,22 @@
 					For general purposes, feel free to refer to this work as Dekker, M.M. (2023) The Carbon
 					Budget Explorer. [Online]. Available: https://www.carbonbudgetexplorer.eu. <br />
 					<br /> For scientific purposes, you can refer to the
-					<a href="https://doi.org/10.21203/rs.3.rs-5023350/v1" target="_blank" rel="noopener noreferrer">preprint</a>
+					<a
+						href="https://doi.org/10.21203/rs.3.rs-5023350/v1"
+						target="_blank"
+						rel="noopener noreferrer">preprint</a
+					>
 					of this work. It is currently under review.
-
 				</QA>
 				<QA question="Will the data and code be publicly available?">
-					All data can be downloaded <a href="https://doi.org/10.5281/zenodo.12188104" target="_blank">from Zenodo</a>,
-					including more recent developments. The Python code for the computations can be found on
+					All data can be downloaded <a
+						href="https://doi.org/10.5281/zenodo.12188104"
+						target="_blank">from Zenodo</a
+					>, including more recent developments. The Python code for the computations can be found
+					on
 					<a href="https://doi.org/10.5281/zenodo.13640303" target="_blank">Zenodo</a> or
-					<a href="https://github.com/imagepbl/EffortSharing/tree/v1.0.0" target="_blank">GitHub</a>.
+					<a href="https://github.com/imagepbl/EffortSharing/tree/v1.0.0" target="_blank">GitHub</a
+					>.
 				</QA>
 				<QA question="What future updates are expected?">
 					The Explorer is constantly in development, by updating NDC or other data, but also in

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -220,6 +220,19 @@
 						rel="noopener noreferrer">Responsibility-Capability Index</a
 					>, and in the long run based on GDP per capita (similar to Ability to Pay).
 				</QA>
+				<QA question="Why are there different absolute NDC values shown in the country graph?">
+					When NDCs area published by countries, they are expressed in relative terms (e.g. 30 % reduction in 2030 compared to 1990).
+					The absolute values are calculations that depend on the historical and baseline emission data used. We show two versions:
+					one based on the data we use for the Carbon Budget Explorer (Jones et al., 2021), and one based on the data used in the
+					<a
+						href="https://themasites.pbl.nl/o/climate-ndc-policies-tool/"
+						target="_blank"
+						rel="noopener noreferrer">PBL NDC tool</a> (PRIMAP historical data).
+					<br />
+					<br />
+					These values are only an indication. When precise NDC data is needed, it is better to refer to the official NDC documents.
+
+				</QA>
 				<QA question="Why are there no NDCs for European Member States?">
 					European Member States have a joint NDC, which is to reduce GHG emissions by at least 55 %
 					by 2030 compared to 1990 levels. This is a shared goal for the EU27, and therefore no
@@ -247,8 +260,10 @@
 				<QA question="How can I cite this work?">
 					For general purposes, feel free to refer to this work as Dekker, M.M. (2023) The Carbon
 					Budget Explorer. [Online]. Available: https://www.carbonbudgetexplorer.eu. <br />
-					<br /> For scientific purposes, we recommend waiting for the scientific preprint that will
-					be available in September 2024.
+					<br /> For scientific purposes, you can refer to the
+					<a href="https://doi.org/10.21203/rs.3.rs-5023350/v1" target="_blank" rel="noopener noreferrer">preprint</a>
+					of this work. It is currently under review.
+
 				</QA>
 				<QA question="Will the data and code be publicly available?">
 					All data can be downloaded <a href="https://doi.org/10.5281/zenodo.12188104" target="_blank">from Zenodo</a>,

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -220,13 +220,14 @@
 						rel="noopener noreferrer">Responsibility-Capability Index</a
 					>, and in the long run based on GDP per capita (similar to Ability to Pay).
 				</QA>
-				<QA question="Why are there no NDCs for European member states?">
-					European member states have a common NDC, which is to reduce GHG emissions by at least 55 %
+				<QA question="Why are there no NDCs for European Member States?">
+					European Member States have a joint NDC, which is to reduce GHG emissions by at least 55 %
 					by 2030 compared to 1990 levels. This is a shared goal for the EU27, and therefore no
-					individual NDCs are available for European member states.
+					individual NDCs are available for European Member States.
 					<br />
 					<br />
-					Which country reduces emissions by how much is determined by European regulation. You can find
+					The allocation of emission reductions to each Member State is determined via several Directives (ETS, ESR and others).
+					You can find
 					<a
 						href="https://data.consilium.europa.eu/doc/document/ST-14286-2023-INIT/en/pdf"
 						target="_blank"

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -50,7 +50,7 @@
 					>
 					projects. For more information you can contact dr.
 					<a
-						href="https://www.uu.nl/medewerkers/MMDekker"
+						href="https://www.pbl.nl/over-het-pbl/medewerkers/mark-dekker"
 						target="_blank"
 						class="text-white"
 						rel="noopener noreferrer">Mark Dekker.</a
@@ -179,7 +179,7 @@
 					and the AR6
 					<a href="https://zenodo.org/records/5886912" target="_blank" rel="noopener noreferrer"
 						>scenario database</a
-					>. For NDC data, we use the Climate Resource NDC factsheets.
+					>. For NDC data, we use the PBL Climate Pledge NDC tool.
 				</QA>
 				<QA question="What are these allocation methods?">
 					Below, we briefly describe the methods one-by-one. For more details, the reader is
@@ -224,22 +224,23 @@
 			<section>
 				<h2 id="other">Other</h2>
 				<QA question="How can I contact you?">
-					All questions, comments and ideas are welcome. Please can dr. <a
-						href="https://www.uu.nl/medewerkers/MMDekker"
+					All questions, comments and ideas are welcome. Please contact dr. <a
+						href="https://www.pbl.nl/over-het-pbl/medewerkers/mark-dekker"
 						target="_blank"
 						rel="noopener noreferrer">Mark Dekker</a
 					> from the Netherlands Environmental Assessment Agency.
 				</QA>
 				<QA question="How can I cite this work?">
-					For general purposes, feel free to refer this work as Dekker, M.M. (2023) The Carbon
+					For general purposes, feel free to refer to this work as Dekker, M.M. (2023) The Carbon
 					Budget Explorer. [Online]. Available: https://www.carbonbudgetexplorer.eu. <br />
-					<br /> For scientific purposes, because the data is still undergoing many developments, we
-					recommend waiting for the preprint of the scientific article (estimated in spring 2024) before
-					citing the research.
+					<br /> For scientific purposes, we recommend waiting for the scientific preprint that will
+					be available in September 2024.
 				</QA>
 				<QA question="Will the data and code be publicly available?">
-					Yes, all data and code (for both this tool and the scientific analysis) will be publicly
-					available. We expect to publish this in spring 2024.
+					All data can be downloaded <a href="https://doi.org/10.5281/zenodo.12188104" target="_blank">from Zenodo</a>,
+					including more recent developments. The Python code for the computations can be found on
+					<a href="https://doi.org/10.5281/zenodo.13640303" target="_blank">Zenodo</a> or
+					<a href="https://github.com/imagepbl/EffortSharing/tree/v1.0.0" target="_blank">GitHub</a>.
 				</QA>
 				<QA question="What future updates are expected?">
 					The Explorer is constantly in development, by updating NDC or other data, but also in

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -220,6 +220,19 @@
 						rel="noopener noreferrer">Responsibility-Capability Index</a
 					>, and in the long run based on GDP per capita (similar to Ability to Pay).
 				</QA>
+				<QA question="Why are there no NDCs for European member states?">
+					European member states have a common NDC, which is to reduce GHG emissions by at least 55 %
+					by 2030 compared to 1990 levels. This is a shared goal for the EU27, and therefore no
+					individual NDCs are available for European member states.
+					<br />
+					<br />
+					Which country reduces emissions by how much is determined by European regulation. You can find
+					<a
+						href="https://data.consilium.europa.eu/doc/document/ST-14286-2023-INIT/en/pdf"
+						target="_blank"
+						rel="noopener noreferrer">more information here.</a>
+				</QA>
+
 			</section>
 			<section>
 				<h2 id="other">Other</h2>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -108,19 +108,25 @@
         					{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
 								{#if isEuMemberState(data.info.iso3)}
 									EU Member States do not have individual NDCs. The EU27's joint NDC target is to reduce GHG
-									emissions by at least 55% by 2030 compared to 1990 levels.
+									emissions by at least 55% by 2030 compared to 1990 levels. This translates to 2085 Mt CO₂e in 2030.
 								{:else}
-									{data.indicators.ndcAmbition.min.toFixed(0)}
+									{#if data.indicators.ndcAmbition.min < 0}
+										{Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase
+									{:else}
+										{data.indicators.ndcAmbition.min.toFixed(0)} % reduction
+									{/if}
 								{/if}
 							{:else}
 								{#if isEuMemberState(data.info.iso3)}
-									EU NDC: {`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
+									EU Member States do not have individual NDCs. The EU27's joint NDC target is to reduce GHG
+									emissions by at least 55% by 2030 compared to 1990 levels. This translates to 2085 Mt CO₂e in 2030.
 								{:else}
-									{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
+									{#if data.indicators.ndcAmbition.min < 0 && data.indicators.ndcAmbition.max < 0}
+										{`${Math.abs(data.indicators.ndcAmbition.max.toFixed(0))} - ${Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase`}
+									{:else}
+										{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)} % reduction`}
+									{/if}
 								{/if}
-							{/if}
-							{#if !isEuMemberState(data.info.iso3)}
-								<span>% reduction</span>
 							{/if}
 						</span>
 					</p>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -69,16 +69,39 @@
 	}
 
 	const euMemberStates = [
-        "AUT", "BEL", "BGR", "HRV", "CYP", "CZE", "DNK",
-        "EST", "FIN", "FRA", "DEU", "GRC", "HUN", "IRL", "ITA",
-        "LVA", "LTU", "LUX", "MLT", "NLD", "POL", "PRT",
-        "ROU", "SVK", "SVN", "ESP", "SWE"
-    ];
+		'AUT',
+		'BEL',
+		'BGR',
+		'HRV',
+		'CYP',
+		'CZE',
+		'DNK',
+		'EST',
+		'FIN',
+		'FRA',
+		'DEU',
+		'GRC',
+		'HUN',
+		'IRL',
+		'ITA',
+		'LVA',
+		'LTU',
+		'LUX',
+		'MLT',
+		'NLD',
+		'POL',
+		'PRT',
+		'ROU',
+		'SVK',
+		'SVN',
+		'ESP',
+		'SWE'
+	];
 
-    // Function to check if the region is an EU member state
-    function isEuMemberState(region: string) {
-        return euMemberStates.includes(region);
-    }
+	// Function to check if the region is an EU member state
+	function isEuMemberState(region: string) {
+		return euMemberStates.includes(region);
+	}
 </script>
 
 <div class="flex h-full flex-row gap-4">
@@ -104,29 +127,29 @@
 						<span class="font-bold"> NDC ambition in 2030 relative to 2015: </span>
 						<span>
 							{#if data.indicators.ndcAmbition === null}
-            					-
-        					{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
+								-
+							{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
 								{#if isEuMemberState(data.info.iso3)}
-									EU Member States do not have individual NDCs. The EU27's joint NDC target is to reduce GHG
-									emissions by at least 55% by 2030 compared to 1990 levels. This translates to 2085 Mt CO₂e in 2030.
+									EU Member States do not have individual NDCs. The EU27's joint NDC target is to
+									reduce GHG emissions by at least 55% by 2030 compared to 1990 levels. This
+									translates to 2085 Mt CO₂e in 2030.
+								{:else if data.indicators.ndcAmbition.min < 0}
+									{Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase
 								{:else}
-									{#if data.indicators.ndcAmbition.min < 0}
-										{Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase
-									{:else}
-										{data.indicators.ndcAmbition.min.toFixed(0)} % reduction
-									{/if}
+									{data.indicators.ndcAmbition.min.toFixed(0)} % reduction
 								{/if}
+							{:else if isEuMemberState(data.info.iso3)}
+								EU Member States do not have individual NDCs. The EU27's joint NDC target is to
+								reduce GHG emissions by at least 55% by 2030 compared to 1990 levels. This
+								translates to 2085 Mt CO₂e in 2030.
+							{:else if data.indicators.ndcAmbition.min < 0 && data.indicators.ndcAmbition.max < 0}
+								{`${Math.abs(data.indicators.ndcAmbition.max.toFixed(0))} - ${Math.abs(
+									data.indicators.ndcAmbition.min.toFixed(0)
+								)} % increase`}
 							{:else}
-								{#if isEuMemberState(data.info.iso3)}
-									EU Member States do not have individual NDCs. The EU27's joint NDC target is to reduce GHG
-									emissions by at least 55% by 2030 compared to 1990 levels. This translates to 2085 Mt CO₂e in 2030.
-								{:else}
-									{#if data.indicators.ndcAmbition.min < 0 && data.indicators.ndcAmbition.max < 0}
-										{`${Math.abs(data.indicators.ndcAmbition.max.toFixed(0))} - ${Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase`}
-									{:else}
-										{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)} % reduction`}
-									{/if}
-								{/if}
+								{`${data.indicators.ndcAmbition.min.toFixed(
+									0
+								)} - ${data.indicators.ndcAmbition.max.toFixed(0)} % reduction`}
 							{/if}
 						</span>
 					</p>
@@ -175,8 +198,6 @@
 								textNdcMax={`Max: ${range[1].toFixed(0)}`}
 								textNdc={`NDC`}
 								color="black"
-
-
 								on:mouseover={hoverNdc}
 								on:mouseout={(e) => (evt = e)}
 							/>
@@ -195,7 +216,6 @@
 							/>
 						{/each} -->
 					{/if}
-
 				</Pathway>
 			</section>
 		</div>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -166,7 +166,7 @@
 						{/if}
 					{/each}
 					{#if !isEuMemberState(data.info.iso3)}
-						{#each Object.entries(data.indicators.ndc) as [year, range]}
+						{#each Object.entries(data.indicators.ndc_inventory) as [year, range]}
 							<NdcRange
 								x={parseInt(year)}
 								y0={range[0]}
@@ -174,12 +174,26 @@
 								textNdcMin={`Min: ${range[0].toFixed(0)}`}
 								textNdcMax={`Max: ${range[1].toFixed(0)}`}
 								textNdc={`NDC`}
+								color="black"
 
 
 								on:mouseover={hoverNdc}
 								on:mouseout={(e) => (evt = e)}
 							/>
 						{/each}
+						<!-- {#each Object.entries(data.indicators.ndc_jones) as [year, range]}
+							<NdcRange
+								x={parseInt(year)}
+								y0={range[0]}
+								y1={range[1]}
+								textNdcMin={` `}
+								textNdcMax={` `}
+								textNdc={` `}
+								color="gray"
+								on:mouseover={hoverNdc}
+								on:mouseout={(e) => (evt = e)}
+							/>
+						{/each} -->
 					{/if}
 
 				</Pathway>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -134,7 +134,7 @@
 									reduce GHG emissions by at least 55% by 2030 compared to 1990 levels. This
 									translates to 2085 Mt CO₂e in 2030.
 								{:else if data.indicators.ndcAmbition.min < 0}
-									{Math.abs(data.indicators.ndcAmbition.min.toFixed(0))} % increase
+									{Math.abs(data.indicators.ndcAmbition.min).toFixed(0)} % increase
 								{:else}
 									{data.indicators.ndcAmbition.min.toFixed(0)} % reduction
 								{/if}
@@ -143,9 +143,9 @@
 								reduce GHG emissions by at least 55% by 2030 compared to 1990 levels. This
 								translates to 2085 Mt CO₂e in 2030.
 							{:else if data.indicators.ndcAmbition.min < 0 && data.indicators.ndcAmbition.max < 0}
-								{`${Math.abs(data.indicators.ndcAmbition.max.toFixed(0))} - ${Math.abs(
-									data.indicators.ndcAmbition.min.toFixed(0)
-								)} % increase`}
+								{`${Math.abs(data.indicators.ndcAmbition.max).toFixed(0)} - ${Math.abs(
+									data.indicators.ndcAmbition.min).toFixed(0)
+								} % increase`}
 							{:else}
 								{`${data.indicators.ndcAmbition.min.toFixed(
 									0

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -23,9 +23,6 @@
 
 	export let data: PageData;
 
-	import type { Region } from '$lib/api';
-	export let info: Region;
-
 	function updateQueryParam(name: string, value: string) {
 		if (browser) {
 			const params = new URLSearchParams($page.url.search);
@@ -79,7 +76,7 @@
     ];
 
     // Function to check if the region is an EU member state
-    function isEuMemberState(region) {
+    function isEuMemberState(region: string) {
         return euMemberStates.includes(region);
     }
 </script>
@@ -110,7 +107,7 @@
             					-
         					{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
 								{#if isEuMemberState(data.info.iso3)}
-									EU member states do not have individual NDCs. The common goal of the EU27 is to reduce GHG
+									EU Member States do not have individual NDCs. The EU27's joint NDC target is to reduce GHG
 									emissions by at least 55% by 2030 compared to 1990 levels.
 								{:else}
 									{data.indicators.ndcAmbition.min.toFixed(0)}
@@ -125,13 +122,6 @@
 							{#if !isEuMemberState(data.info.iso3)}
 								<span>% reduction</span>
 							{/if}
-
-
-							<!-- {data.indicators.ndcAmbition === null
-								? '-'
-								// : data.indicators.ndcAmbition.toFixed(0)}
-								: `${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`} -->
-
 						</span>
 					</p>
 				</div>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -110,11 +110,8 @@
 								? '-'
 								// : data.indicators.ndcAmbition.toFixed(0)}
 								: `${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`} -->
-								<span
-								class="tooltip cursor-pointer"
-								role="tooltip"
-								data-tip="The NDC data used here is outdated. It will be updated in the next round."
-								>% reduction ⓘ
+								<span>
+									% reduction
 							</span>
 						</span>
 					</p>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -137,16 +137,6 @@
 						on:mouseover={hoverHistoricalCarbon}
 						on:mouseout={(e) => (evt = e)}
 					/>
-					{#each Object.entries(data.indicators.ndc) as [year, range]}
-						<NdcRange
-							x={parseInt(year)}
-							y0={range[0]}
-							y1={range[1]}
-							text0={`Min: ${range[0].toFixed(0)}`}
-							on:mouseover={hoverNdc}
-							on:mouseout={(e) => (evt = e)}
-						/>
-					{/each}
 					{#each Object.entries(principles) as [id, { color, label }]}
 						{#if activeEffortSharings[id]}
 							<g name={id}>
@@ -163,6 +153,21 @@
 							</g>
 						{/if}
 					{/each}
+					{#each Object.entries(data.indicators.ndc) as [year, range]}
+						<NdcRange
+							x={parseInt(year)}
+							y0={range[0]}
+							y1={range[1]}
+							textNdcMin={`Min: ${range[0].toFixed(0)}`}
+							textNdcMax={`Max: ${range[1].toFixed(0)}`}
+							textNdc={`NDC`}
+
+
+							on:mouseover={hoverNdc}
+							on:mouseout={(e) => (evt = e)}
+						/>
+					{/each}
+
 				</Pathway>
 			</section>
 		</div>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -23,6 +23,9 @@
 
 	export let data: PageData;
 
+	import type { Region } from '$lib/api';
+	export let info: Region;
+
 	function updateQueryParam(name: string, value: string) {
 		if (browser) {
 			const params = new URLSearchParams($page.url.search);
@@ -67,6 +70,18 @@
 			(row) => `${id} in ${row.time} is ${row.mean.toFixed(0)} Mt CO₂e (with default settings)`
 		);
 	}
+
+	const euMemberStates = [
+        "AUT", "BEL", "BGR", "HRV", "CYP", "CZE", "DNK",
+        "EST", "FIN", "FRA", "DEU", "GRC", "HUN", "IRL", "ITA",
+        "LVA", "LTU", "LUX", "MLT", "NLD", "POL", "PRT",
+        "ROU", "SVK", "SVN", "ESP", "SWE"
+    ];
+
+    // Function to check if the region is an EU member state
+    function isEuMemberState(region) {
+        return euMemberStates.includes(region);
+    }
 </script>
 
 <div class="flex h-full flex-row gap-4">
@@ -88,31 +103,35 @@
 			<CountryHeader info={data.info} />
 			<section id="key-indicators">
 				<div class="px-12">
-					<!-- <p>
-						<span class="font-bold"> Historical emissions: </span>
-						<span>
-							{(data.indicators.historicalCarbon / 1_000).toFixed()}
-							Gt CO₂e
-						</span>
-					</p> -->
 					<p>
 						<span class="font-bold"> NDC ambition in 2030 relative to 2015: </span>
 						<span>
 							{#if data.indicators.ndcAmbition === null}
             					-
         					{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
-            					{data.indicators.ndcAmbition.min.toFixed(0)}
-        					{:else}
-            					{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
-        					{/if}
+								{#if isEuMemberState(data.info.iso3)}
+									EU member states do not have individual NDCs. The common goal of the EU27 is to reduce GHG
+									emissions by at least 55% by 2030 compared to 1990 levels.
+								{:else}
+									{data.indicators.ndcAmbition.min.toFixed(0)}
+								{/if}
+							{:else}
+								{#if isEuMemberState(data.info.iso3)}
+									EU NDC: {`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
+								{:else}
+									{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
+								{/if}
+							{/if}
+							{#if !isEuMemberState(data.info.iso3)}
+								<span>% reduction</span>
+							{/if}
+
 
 							<!-- {data.indicators.ndcAmbition === null
 								? '-'
 								// : data.indicators.ndcAmbition.toFixed(0)}
 								: `${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`} -->
-								<span>
-									% reduction
-							</span>
+
 						</span>
 					</p>
 				</div>
@@ -150,20 +169,22 @@
 							</g>
 						{/if}
 					{/each}
-					{#each Object.entries(data.indicators.ndc) as [year, range]}
-						<NdcRange
-							x={parseInt(year)}
-							y0={range[0]}
-							y1={range[1]}
-							textNdcMin={`Min: ${range[0].toFixed(0)}`}
-							textNdcMax={`Max: ${range[1].toFixed(0)}`}
-							textNdc={`NDC`}
+					{#if !isEuMemberState(data.info.iso3)}
+						{#each Object.entries(data.indicators.ndc) as [year, range]}
+							<NdcRange
+								x={parseInt(year)}
+								y0={range[0]}
+								y1={range[1]}
+								textNdcMin={`Min: ${range[0].toFixed(0)}`}
+								textNdcMax={`Max: ${range[1].toFixed(0)}`}
+								textNdc={`NDC`}
 
 
-							on:mouseover={hoverNdc}
-							on:mouseout={(e) => (evt = e)}
-						/>
-					{/each}
+								on:mouseover={hoverNdc}
+								on:mouseout={(e) => (evt = e)}
+							/>
+						{/each}
+					{/if}
 
 				</Pathway>
 			</section>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -144,8 +144,8 @@
 								translates to 2085 Mt CO₂e in 2030.
 							{:else if data.indicators.ndcAmbition.min < 0 && data.indicators.ndcAmbition.max < 0}
 								{`${Math.abs(data.indicators.ndcAmbition.max).toFixed(0)} - ${Math.abs(
-									data.indicators.ndcAmbition.min).toFixed(0)
-								} % increase`}
+									data.indicators.ndcAmbition.min
+								).toFixed(0)} % increase`}
 							{:else}
 								{`${data.indicators.ndcAmbition.min.toFixed(
 									0

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -88,23 +88,34 @@
 			<CountryHeader info={data.info} />
 			<section id="key-indicators">
 				<div class="px-12">
-					<p>
+					<!-- <p>
 						<span class="font-bold"> Historical emissions: </span>
 						<span>
 							{(data.indicators.historicalCarbon / 1_000).toFixed()}
 							Gt CO₂e
 						</span>
-					</p>
+					</p> -->
 					<p>
-						<span class="font-bold"> NDC ambition in 2030 relative to 1990: </span><span
-							>{data.indicators.ndcAmbition === null
+						<span class="font-bold"> NDC ambition in 2030 relative to 2015: </span>
+						<span>
+							{#if data.indicators.ndcAmbition === null}
+            					-
+        					{:else if data.indicators.ndcAmbition.min === data.indicators.ndcAmbition.max}
+            					{data.indicators.ndcAmbition.min.toFixed(0)}
+        					{:else}
+            					{`${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`}
+        					{/if}
+
+							<!-- {data.indicators.ndcAmbition === null
 								? '-'
-								: data.indicators.ndcAmbition.toFixed(0)}<span
+								// : data.indicators.ndcAmbition.toFixed(0)}
+								: `${data.indicators.ndcAmbition.min.toFixed(0)} - ${data.indicators.ndcAmbition.max.toFixed(0)}`} -->
+								<span
 								class="tooltip cursor-pointer"
 								role="tooltip"
 								data-tip="The NDC data used here is outdated. It will be updated in the next round."
-								>% reduction ⓘ</span
-							>
+								>% reduction ⓘ
+							</span>
 						</span>
 					</p>
 				</div>

--- a/src/routes/regions/[iso]/+page.svelte
+++ b/src/routes/regions/[iso]/+page.svelte
@@ -57,7 +57,7 @@
 	);
 	const hoverNdc = hoverBuilder(
 		(row) =>
-			`Nationally determined contribution at ${row.time} ranges from ${row.max.toFixed(
+			`Nationally determined contribution in ${row.time} ranges from ${row.max.toFixed(
 				0
 			)} to ${row.min.toFixed(0)} Mt CO₂e`
 	);
@@ -131,6 +131,7 @@
 							x={parseInt(year)}
 							y0={range[0]}
 							y1={range[1]}
+							text0={`Min: ${range[0].toFixed(0)}`}
 							on:mouseover={hoverNdc}
 							on:mouseout={(e) => (evt = e)}
 						/>

--- a/ws.py
+++ b/ws.py
@@ -28,7 +28,7 @@ CORS(app)
 # TODO write tests with dummy data
 
 # DATA_PATH = Path("/data/DataUpdate_NDC_06_2024")
-DATA_PATH = Path("/Data/Data_effortsharing/DataUpdate_08_2024")
+DATA_PATH = Path("/data/DataUpdate_08_2024")
 
 # Global data (xr_dataread.nc)
 dsGlobal = xr.open_dataset(DATA_PATH / "xr_dataread.nc")

--- a/ws.py
+++ b/ws.py
@@ -28,7 +28,7 @@ CORS(app)
 # TODO write tests with dummy data
 
 # DATA_PATH = Path("/data/DataUpdate_NDC_06_2024")
-DATA_PATH = Path("/data/DataUpdate_08_2024")
+DATA_PATH = Path("/data/DataUpdate_10_2024")
 
 # Global data (xr_dataread.nc)
 dsGlobal = xr.open_dataset(DATA_PATH / "xr_dataread.nc")
@@ -432,16 +432,24 @@ def isEU(region):
 def ndcAmbition(region):
     region = isEU(region)
 
-    ndc2030_min = dsGlobal.GHG_ndc.sel(Region=region).min().values.tolist()
-    ndc2030_max = dsGlobal.GHG_ndc.sel(Region=region).max().values.tolist()
+    ndc2030_min = dsGlobal.GHG_ndc_red.sel(Region=region).min().values.tolist()
+    ndc2030_max = dsGlobal.GHG_ndc_red.sel(Region=region).max().values.tolist()
 
-    if np.isnan(ndc2030_min) or np.isnan(ndc2030_max):
-        return None
-    hist2015 = dsGlobal.GHG_hist.sel(Region=region, Time=2015).values.tolist()
     return {
-        "min": -(ndc2030_max - hist2015) / hist2015 * 100,
-        "max": -(ndc2030_min - hist2015) / hist2015 * 100
+        "min": ndc2030_min * 100,
+        "max": ndc2030_max * 100
     }
+
+    # ndc2030_min = dsGlobal.GHG_ndc.sel(Region=region).min().values.tolist()
+    # ndc2030_max = dsGlobal.GHG_ndc.sel(Region=region).max().values.tolist()
+
+    # if np.isnan(ndc2030_min) or np.isnan(ndc2030_max):
+    #     return None
+    # hist2015 = dsGlobal.GHG_hist.sel(Region=region, Time=2015).values.tolist()
+    # return {
+    #     "min": -(ndc2030_max - hist2015) / hist2015 * 100,
+    #     "max": -(ndc2030_min - hist2015) / hist2015 * 100
+    # }
 
 
 def historicalCarbonIndicator(region, start, end):
@@ -452,10 +460,20 @@ def historicalCarbonIndicator(region, start, end):
     )
 
 
-def ndcRange(region):
+def ndcRange_inventory(region):
+    # Absolute emissions from the NDC, based on self-reported inventory data
     region = isEU(region)
-    ds = dsGlobal.GHG_ndc.sel(Region=region)
-    return {2030: [ds.min().values.tolist(), ds.max().values.tolist()]}
+
+    ds_ndc_inv = dsGlobal.GHG_ndc_inv.sel(Region=region)
+    return {2030: [ds_ndc_inv.min().values.tolist(), ds_ndc_inv.max().values.tolist()]}
+
+
+def ndcRange_jones(region):
+    # Is using GHGH_ndc_red to get absolute emissions, but then using 2015 Jones data
+    region = isEU(region)
+
+    ds_ndc = dsGlobal.GHG_ndc.sel(Region=region)
+    return {2030: [ds_ndc.min().values.tolist(), ds_ndc.max().values.tolist()]}
 
 
 @app.get("/indicators/<region>")
@@ -465,7 +483,8 @@ def indicators(region):
     data = {
         "ndcAmbition": ndcAmbition(region),
         "historicalCarbon": historicalCarbonIndicator(region, start, end),
-        "ndc": ndcRange(region),
+        "ndc_inventory": ndcRange_inventory(region),
+        "ndc_jones": ndcRange_jones(region)
     }
     return data
 
@@ -565,7 +584,8 @@ def effortSharingReductions(ISO):
     return reductions
 
 if __name__ == "__main__":
-    region = input("Choose a focus country or region: ")
+    # region = input("Choose a focus country or region: ")
+    region = "USA"
     # print(f"NDC Ambition in 2030 relative to 2015: {ndcAmbition(region)}% reduction")
     # print(f"NDC Range: {ndcRange(region)}")
-    policyPathway("CurPol", region)
+    print(ndcAmbition(region))

--- a/ws.py
+++ b/ws.py
@@ -424,13 +424,22 @@ def policyPathway(policy, region):
 #     return -(ndc2030 - hist1990) / hist1990 * 100
 
 def ndcAmbition(region):
-    ndc2030 = dsGlobal.GHG_ndc.sel(Region=region).mean().values.tolist()
-    if np.isnan(ndc2030):
+    # ndc2030 = dsGlobal.GHG_ndc.sel(Region=region).mean().values.tolist()
+    ndc2030_min = dsGlobal.GHG_ndc.sel(Region=region).min().values.tolist()
+    ndc2030_max = dsGlobal.GHG_ndc.sel(Region=region).max().values.tolist()
+
+    if np.isnan(ndc2030_min) or np.isnan(ndc2030_max):
         return None
-    hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
+    # hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
     hist2015 = dsGlobal.GHG_hist.sel(Region=region, Time=2015).values.tolist()
     # return -(ndc2030 - hist1990) / hist1990 * 100
-    return -(ndc2030 - hist2015) / hist2015 * 100
+    # percent_reduction = -(ndc2030 - hist2015) / hist2015 * 100
+    return {
+        # "mean": percent_reduction,
+        "min": -(ndc2030_max - hist2015) / hist2015 * 100,
+        "max": -(ndc2030_min - hist2015) / hist2015 * 100
+    }
+    # return -(ndc2030 - hist2015) / hist2015 * 100
 
 
 def historicalCarbonIndicator(region, start, end):
@@ -555,3 +564,9 @@ def effortSharingReductions(ISO):
                 reductions[principle][period] = -(es - hist) / hist * 100
 
     return reductions
+
+if __name__ == "__main__":
+    region = input("Choose a focus country or region: ")
+    print(f"NDC Ambition in 2030 relative to 2015: {ndcAmbition(region)}% reduction")
+    print(f"NDC Range: {ndcRange(region)}")
+    # app.run(debug=True)

--- a/ws.py
+++ b/ws.py
@@ -416,30 +416,31 @@ def policyPathway(policy, region):
     return df.reset_index().to_dict(orient="records")
 
 
-# def ndcAmbition(region):
-#     ndc2030 = dsGlobal.GHG_ndc.sel(Region=region, Time=2030).mean().values.tolist()
-#     if np.isnan(ndc2030):
-#         return None
-#     hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
-#     return -(ndc2030 - hist1990) / hist1990 * 100
+def isEU(region):
+    # EU member states do not have individual NDCs but are covered by the EU NDC
+    member_states = [
+        "AUT", "BEL", "BGR", "HRV", "CYP", "CZE", "DNK", "EST", "FIN", "FRA",
+        "DEU", "GRC", "HUN", "IRL", "ITA", "LVA", "LTU", "LUX", "MLT", "NLD",
+        "POL", "PRT", "ROU", "SVK", "SVN", "ESP", "SWE"
+    ]
+    if region in member_states:
+        return "EU"
+    return region
+
 
 def ndcAmbition(region):
-    # ndc2030 = dsGlobal.GHG_ndc.sel(Region=region).mean().values.tolist()
+    region = isEU(region)
+
     ndc2030_min = dsGlobal.GHG_ndc.sel(Region=region).min().values.tolist()
     ndc2030_max = dsGlobal.GHG_ndc.sel(Region=region).max().values.tolist()
 
     if np.isnan(ndc2030_min) or np.isnan(ndc2030_max):
         return None
-    # hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
     hist2015 = dsGlobal.GHG_hist.sel(Region=region, Time=2015).values.tolist()
-    # return -(ndc2030 - hist1990) / hist1990 * 100
-    # percent_reduction = -(ndc2030 - hist2015) / hist2015 * 100
     return {
-        # "mean": percent_reduction,
         "min": -(ndc2030_max - hist2015) / hist2015 * 100,
         "max": -(ndc2030_min - hist2015) / hist2015 * 100
     }
-    # return -(ndc2030 - hist2015) / hist2015 * 100
 
 
 def historicalCarbonIndicator(region, start, end):
@@ -449,12 +450,9 @@ def historicalCarbonIndicator(region, start, end):
         .values.tolist()
     )
 
-# def ndcRange(region, period=2030):
-#     ds = dsGlobal.GHG_ndc.sel(Region=region, Time=period)
-#     return {period: [ds.min().values.tolist(), ds.max().values.tolist()]}
-
 
 def ndcRange(region):
+    region = isEU(region)
     ds = dsGlobal.GHG_ndc.sel(Region=region)
     return {2030: [ds.min().values.tolist(), ds.max().values.tolist()]}
 
@@ -505,7 +503,7 @@ def effortSharing(ISO, principle):
     if principle == "GDR":
         mr_selection.update(RCI_weight=DEFAULT_RCI_WEIGHT,
                             Capability_threshold=DEFAULT_CAPABILITY_THRESHOLD)
-        
+
     mr_df = ds.sel(**mr_selection).to_pandas().rename("mean")
 
     agg_dims = [dim for dim in ds.dims if dim != "time"]
@@ -569,4 +567,4 @@ if __name__ == "__main__":
     region = input("Choose a focus country or region: ")
     print(f"NDC Ambition in 2030 relative to 2015: {ndcAmbition(region)}% reduction")
     print(f"NDC Range: {ndcRange(region)}")
-    # app.run(debug=True)
+

--- a/ws.py
+++ b/ws.py
@@ -410,7 +410,8 @@ def policyPathway(policy, region):
     ).to_pandas()
 
     if region == "EARTH":
-        df /= 1000  # global GHG in Gt CO2e
+        columns_to_divide = ['mean', 'min', 'max']
+        df[columns_to_divide] = df[columns_to_divide] / 1000  # global GHG in Gt CO2e
 
     df.index.rename("time", inplace=True)
     return df.reset_index().to_dict(orient="records")
@@ -565,6 +566,6 @@ def effortSharingReductions(ISO):
 
 if __name__ == "__main__":
     region = input("Choose a focus country or region: ")
-    print(f"NDC Ambition in 2030 relative to 2015: {ndcAmbition(region)}% reduction")
-    print(f"NDC Range: {ndcRange(region)}")
-
+    # print(f"NDC Ambition in 2030 relative to 2015: {ndcAmbition(region)}% reduction")
+    # print(f"NDC Range: {ndcRange(region)}")
+    policyPathway("CurPol", region)

--- a/ws.py
+++ b/ws.py
@@ -27,7 +27,8 @@ CORS(app)
 # TODO use class-based views for a reusable nc-file viewer?
 # TODO write tests with dummy data
 
-DATA_PATH = Path("/data/DataUpdate_02_2024")
+# DATA_PATH = Path("/data/DataUpdate_NDC_06_2024")
+DATA_PATH = Path("/data/DataUpdate_08_2024")
 
 # Global data (xr_dataread.nc)
 dsGlobal = xr.open_dataset(DATA_PATH / "xr_dataread.nc")
@@ -415,12 +416,21 @@ def policyPathway(policy, region):
     return df.reset_index().to_dict(orient="records")
 
 
+# def ndcAmbition(region):
+#     ndc2030 = dsGlobal.GHG_ndc.sel(Region=region, Time=2030).mean().values.tolist()
+#     if np.isnan(ndc2030):
+#         return None
+#     hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
+#     return -(ndc2030 - hist1990) / hist1990 * 100
+
 def ndcAmbition(region):
-    ndc2030 = dsGlobal.GHG_ndc.sel(Region=region, Time=2030).mean().values.tolist()
+    ndc2030 = dsGlobal.GHG_ndc.sel(Region=region).mean().values.tolist()
     if np.isnan(ndc2030):
         return None
     hist1990 = dsGlobal.GHG_hist.sel(Region=region, Time=1990).values.tolist()
-    return -(ndc2030 - hist1990) / hist1990 * 100
+    hist2015 = dsGlobal.GHG_hist.sel(Region=region, Time=2015).values.tolist()
+    # return -(ndc2030 - hist1990) / hist1990 * 100
+    return -(ndc2030 - hist2015) / hist2015 * 100
 
 
 def historicalCarbonIndicator(region, start, end):
@@ -430,10 +440,14 @@ def historicalCarbonIndicator(region, start, end):
         .values.tolist()
     )
 
+# def ndcRange(region, period=2030):
+#     ds = dsGlobal.GHG_ndc.sel(Region=region, Time=period)
+#     return {period: [ds.min().values.tolist(), ds.max().values.tolist()]}
 
-def ndcRange(region, period=2030):
-    ds = dsGlobal.GHG_ndc.sel(Region=region, Time=period)
-    return {period: [ds.min().values.tolist(), ds.max().values.tolist()]}
+
+def ndcRange(region):
+    ds = dsGlobal.GHG_ndc.sel(Region=region)
+    return {2030: [ds.min().values.tolist(), ds.max().values.tolist()]}
 
 
 @app.get("/indicators/<region>")

--- a/ws.py
+++ b/ws.py
@@ -28,7 +28,7 @@ CORS(app)
 # TODO write tests with dummy data
 
 # DATA_PATH = Path("/data/DataUpdate_NDC_06_2024")
-DATA_PATH = Path("/data/DataUpdate_08_2024")
+DATA_PATH = Path("/Data/Data_effortsharing/DataUpdate_08_2024")
 
 # Global data (xr_dataread.nc)
 dsGlobal = xr.open_dataset(DATA_PATH / "xr_dataread.nc")


### PR DESCRIPTION
@Peter9192 
These are the changes that I have worked on to update the explorer. 
## On country page: 
- Removed "historical emissions" under title of page
- Adapted "NDC ambition in 2030" and made it relative to 2015 instead of 1990; also added functionality that shows ranges of reduction; for EU countries shows no ranges but a text; ranges showing either X% reduction or % increase
- Updated table to show all numbers relative to 2015 instead of 1990
- Visualisation of NDC dot: Moved the dot to the top layer, made it bigger, added text to show ranges in numbers, added text that says "NDC"; prepared adding a second dot to show the second data source for NDC
## On other pages:
- Q&A section expanded and updated
- Mention of new data update in header of website updated
## Behind the scenes: 
- Adapting data path to fit new data structure
- Adapted a few functions in ws.py to read new NDC data
- Changed artifact version to make GitHub action work again

As we discussed earlier, these updates have been in the pipeline for a long time now so commits go back quite a while. If anything is unclear let me know. 
