### PR TITLE
Split static data from searchparam dependend

### DIFF
--- a/src/routes/map/+layout.server.ts
+++ b/src/routes/map/+layout.server.ts
@@ -1,0 +1,14 @@
+import { borders as bordersDb } from '$lib/server/db/data';
+import {
+	listRegions} from '$lib/api';
+
+export async function load() {
+	const regions = await listRegions();
+
+	const data = {
+		borders: bordersDb.geojson,
+		regions
+	};
+
+	return data;
+}

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -1,10 +1,8 @@
-import { borders as bordersDb } from '$lib/server/db/data';
 import { searchParam } from '$lib/searchparam';
 import {
 	currentPolicy,
 	fullCenturyBudgetSpatial,
 	historicalCarbon,
-	listRegions,
 	pathwayCarbon,
 	pathwayChoices,
 	pathwayQueryFromSearchParams,
@@ -38,7 +36,6 @@ export async function load({ url }: { url: URL }) {
 		rawMetrics = await fullCenturyBudgetSpatial(selectedAllocationTime, url.search);
 	}
 
-	const regions = await listRegions();
 	const metrics = {
 		data: rawMetrics.data,
 		domain: rawMetrics.domain
@@ -54,9 +51,8 @@ export async function load({ url }: { url: URL }) {
 		pathway,
 		effortSharing: selectedEffortSharing,
 		metrics,
-		borders: bordersDb.geojson,
-		regions,
 		global
 	};
+
 	return data;
 }

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -9,8 +9,7 @@
 	import ShareTabs from '$lib/ShareTabs.svelte';
 	import MiniPathwayCard from '$lib/MiniPathwayCard.svelte';
 	import AllocationCard from '$lib/AllocationCard.svelte';
-	import type { GeoJSON } from 'geojson';
-
+	
 	import type { PageData } from './$types';
 	import GlobalQueryCard from '$lib/GlobalQueryCard.svelte';
 	import GlobalBudgetCard from '$lib/GlobalBudgetCard.svelte';


### PR DESCRIPTION
Before
- 1 json request of 411kB every time you change filter
After
- 1 json request on page load of 407kB
- 1 json request of 26.1kB every time you change filter

Should use making /map page quicker on slow connections

Should be merged after #33 