### PR TITLE
Change back to using env var for CABE_API_URL as deployments make use…

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { principles } from '$lib/principles';
-import { browser } from '$app/environment';
+import { browser, dev } from '$app/environment';
 
 export interface SpatialMetric {
 	ISO: string;
@@ -82,7 +82,9 @@ export function pathwayQueryFromSearchParams(
 	};
 }
 
-export const API_URL = 'http://127.0.0.1:5000';
+export const API_URL = dev
+       ? import.meta.env.CABE_API_URL ?? 'http://127.0.0.1:5000'
+       : process.env.CABE_API_URL ?? 'http://127.0.0.1:5000'
 
 async function getJSON(path: string, myfetch = fetch) {
 	let url = `${API_URL}${path}`;


### PR DESCRIPTION
… of it.

After build you have a chunk in build/server that has
```js
const API_URL = process.env.CABE_API_URL ?? "http://127.0.0.1:5000";`
```
Which should work on deployment machine.