### PR TITLE
Use robinson projection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"d3-scale-chromatic": "^3.0.0",
 				"driver.js": "^1.3.1",
 				"layercake": "^8.4.0",
+				"proj4leaflet": "^1.0.2",
 				"sveaflet": "^0.1.3"
 			},
 			"devDependencies": {
@@ -30,6 +31,7 @@
 				"@types/d3": "^7.4.0",
 				"@types/leaflet": "1.9.12",
 				"@types/node": "^22.10.7",
+				"@types/proj4leaflet": "^1.0.10",
 				"@vitest/coverage-v8": "^3.0.5",
 				"autoprefixer": "^10.4.20",
 				"daisyui": "^3.9.3",
@@ -3166,6 +3168,25 @@
 				"@types/pg": "*"
 			}
 		},
+		"node_modules/@types/proj4": {
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.6.tgz",
+			"integrity": "sha512-zfMrPy9fx+8DchqM0kIUGeu2tTVB5ApO1KGAYcSGFS8GoqRIkyL41xq2yCx/iV3sOLzo7v4hEgViSLTiPI1L0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/proj4leaflet": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@types/proj4leaflet/-/proj4leaflet-1.0.10.tgz",
+			"integrity": "sha512-Yie5J8sHUgTQ1FTRP9cCDXpWvHXjUiSjwlnJb1F06Czwo6cVOt8Bxy6txMSIVgznbnRWlbYmxNjWDhYtNxAflw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*",
+				"@types/leaflet": "*",
+				"@types/proj4": "*"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -5946,6 +5967,12 @@
 				"node": ">=10.4.0"
 			}
 		},
+		"node_modules/mgrs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+			"integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+			"license": "MIT"
+		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6777,6 +6804,25 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/proj4": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
+			"integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
+			"license": "MIT",
+			"dependencies": {
+				"mgrs": "1.0.0",
+				"wkt-parser": "^1.4.0"
+			}
+		},
+		"node_modules/proj4leaflet": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/proj4leaflet/-/proj4leaflet-1.0.2.tgz",
+			"integrity": "sha512-6GdDeUlhX/tHUiMEj80xQhlPjwrXcdfD0D5OBymY8WvxfbmZcdhNqQk7n7nFf53ue6QdP9ls9ZPjsAxnbZDTsw==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"proj4": "^2.3.14"
 			}
 		},
 		"node_modules/proxy-from-env": {
@@ -8394,6 +8440,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/wkt-parser": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+			"integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
+			"license": "MIT"
 		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@types/d3": "^7.4.0",
 		"@types/leaflet": "1.9.12",
 		"@types/node": "^22.10.7",
+		"@types/proj4leaflet": "^1.0.10",
 		"@vitest/coverage-v8": "^3.0.5",
 		"autoprefixer": "^10.4.20",
 		"daisyui": "^3.9.3",
@@ -56,6 +57,7 @@
 		"d3-scale-chromatic": "^3.0.0",
 		"driver.js": "^1.3.1",
 		"layercake": "^8.4.0",
+		"proj4leaflet": "^1.0.2",
 		"sveaflet": "^0.1.3"
 	}
 }

--- a/src/lib/charts/LeafletMap.svelte
+++ b/src/lib/charts/LeafletMap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { run } from 'svelte/legacy';
 
-	import { Map, GeoJSON, TileLayer } from 'sveaflet';
+	import { Map, GeoJSON } from 'sveaflet';
 	import * as L from 'leaflet';
 	// Load proj4leaflet plugin so L.Proj.CRS is available
 	import 'proj4leaflet';

--- a/src/lib/charts/LeafletMap.svelte
+++ b/src/lib/charts/LeafletMap.svelte
@@ -2,7 +2,9 @@
 	import { run } from 'svelte/legacy';
 
 	import { Map, GeoJSON, TileLayer } from 'sveaflet';
-	// import {CRS} from 'leaflet?client'
+	import * as L from "leaflet";
+	// Load proj4leaflet plugin so L.Proj.CRS is available
+	import "proj4leaflet";
 	import type { BordersCollection } from '$lib/server/db/borders';
 	import 'leaflet/dist/leaflet.css';
 	import { browser } from '$app/environment';
@@ -14,11 +16,19 @@
 	import type { GeoJSONOptions, MapOptions, GeoJSON as GeoJSONT, LeafletMouseEvent } from 'leaflet';
 	import type { Feature, Geometry } from 'geojson';
 
+	const robinson = new L.Proj.CRS(
+		"ESRI:54030","+proj=robin +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs",
+		{
+			resolutions: [ 131072, 65536, 32768, 16384, 8192, 4096, 2048]
+		}
+	)
+
 	const mapOptions: MapOptions = {
-		center: [30, 5],
+		center: [10, -5],
 		zoom: 3,
 		minZoom: 2,
-		zoomControl: false
+		zoomControl: false,
+		crs: robinson
 	};
 	if (browser) {
 		// mapOptions.crs = CRS.EPSG4326

--- a/src/lib/charts/LeafletMap.svelte
+++ b/src/lib/charts/LeafletMap.svelte
@@ -31,20 +31,6 @@
 		zoomControl: false,
 		crs: robinson
 	};
-	if (browser) {
-		// mapOptions.crs = CRS.EPSG4326
-	}
-
-	const tileUrl = 'https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.{ext}';
-	const tileLayerOptions = {
-		minZoom: 4,
-		maxZoom: 20,
-		maxNativeZoom: 19,
-		attribution:
-			'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-		ext: 'png',
-		subdomains: 'abcd'
-	};
 
 	const interpolator = interpolateYlGnBu;
 
@@ -140,7 +126,6 @@
 <div class="h-full w-full" id="leaflet-wrapper">
 	{#if browser}
 		<Map options={mapOptions}>
-			<TileLayer url={tileUrl} options={tileLayerOptions} />
 			<GeoJSON json={borders} options={geoJsonOptions} bind:instance={geojsonlayer} />
 		</Map>
 		<ColorLegend title={'Emissions allocation per capita (t CO2e/pc)'} {scale} />

--- a/src/lib/charts/LeafletMap.svelte
+++ b/src/lib/charts/LeafletMap.svelte
@@ -25,7 +25,7 @@
 	);
 
 	const mapOptions: MapOptions = {
-		center: [10, -5],
+		center: [10, 20],
 		zoom: 3,
 		minZoom: 2,
 		zoomControl: false,

--- a/src/lib/charts/LeafletMap.svelte
+++ b/src/lib/charts/LeafletMap.svelte
@@ -2,9 +2,9 @@
 	import { run } from 'svelte/legacy';
 
 	import { Map, GeoJSON, TileLayer } from 'sveaflet';
-	import * as L from "leaflet";
+	import * as L from 'leaflet';
 	// Load proj4leaflet plugin so L.Proj.CRS is available
-	import "proj4leaflet";
+	import 'proj4leaflet';
 	import type { BordersCollection } from '$lib/server/db/borders';
 	import 'leaflet/dist/leaflet.css';
 	import { browser } from '$app/environment';
@@ -17,11 +17,12 @@
 	import type { Feature, Geometry } from 'geojson';
 
 	const robinson = new L.Proj.CRS(
-		"ESRI:54030","+proj=robin +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs",
+		'ESRI:54030',
+		'+proj=robin +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +type=crs',
 		{
-			resolutions: [ 131072, 65536, 32768, 16384, 8192, 4096, 2048]
+			resolutions: [131072, 65536, 32768, 16384, 8192, 4096, 2048]
 		}
-	)
+	);
 
 	const mapOptions: MapOptions = {
 		center: [10, -5],


### PR DESCRIPTION
Fixes #49

Uses https://github.com/kartena/Proj4Leaflet as suggested at https://leafletjs.com/reference.html#crs-l-crs-base

TODO
- [ ] cartocdn.com/light_only_labels base map no longer visible. Make working or remove basemap
- [ ] show whole globe, can not see whole globe without having white bars above/below, for now crop out asia

Before with default EPSG3857 as crs
![localhost_5173_map_nonCO2red=0 67 allocTime=2030 effortSharing=ECPC temperature=2 4 (1)](https://github.com/user-attachments/assets/8c3f0065-c5bb-4a89-9ab9-4da0aa7c0c57)

With this PR use ESRI:54030 as crs
![localhost_5173_map_nonCO2red=0 67 allocTime=2030 effortSharing=GF temperature=2 4](https://github.com/user-attachments/assets/f0c4540c-6207-4da4-8f64-3cb24d4fe9c6)
